### PR TITLE
Adding API to get ovs controller state

### DIFF
--- a/api/Controller.go
+++ b/api/Controller.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/nuagenetworks/libvrsdk/ovsdb"
+)
+
+//ControllerState is for connection state
+type ControllerState string
+
+const (
+	//ControllerConnected if ovs is connected to controller
+	ControllerConnected ControllerState = "connected"
+	//ControllerDisconnected if ovs is disconnected from controller
+	ControllerDisconnected ControllerState = "disconnected"
+	//ControllerStateUnknown if ovs is disconnected from controller
+	ControllerStateUnknown ControllerState = "unknown"
+	//MasterController is the master controller for this ovs
+	MasterController string = "master"
+)
+
+//GetControllerState return the state of the controller connection
+func (vrsConnection *VRSConnection) GetControllerState() (ControllerState, error) {
+
+	readRowArgs := ovsdb.ReadRowArgs{
+		Columns:   []string{ovsdb.ControllerTableColumnRole},
+		Condition: []string{ovsdb.ControllerTableColumnRole, "==", MasterController},
+	}
+
+	rows, err := vrsConnection.controllerTable.ReadRows(vrsConnection.ovsdbClient, readRowArgs)
+	if err != nil {
+		return ControllerStateUnknown, fmt.Errorf("Unable to controller state info %v", err)
+	}
+
+	if len(rows) != 1 {
+		return ControllerDisconnected, nil
+	}
+
+	return ControllerConnected, nil
+}

--- a/api/Controller_test.go
+++ b/api/Controller_test.go
@@ -1,23 +1,58 @@
 package api
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nuagenetworks/libvrsdk/ovsdb"
+	testutils "github.com/nuagenetworks/libvrsdk/test/util/table"
+	"github.com/socketplane/libovsdb"
+)
+
+type controllerTableTestVec struct {
+	readRows func(ovs *libovsdb.OvsdbClient, readRowArgs ovsdb.ReadRowArgs) ([]map[string]interface{}, error)
+	out      ControllerState
+	err      error
+}
 
 func TestGetControllerState(t *testing.T) {
-	var err error
-	var state ControllerState
-	var vrsConnection VRSConnection
 
-	vrsConnection, err = NewUnixSocketConnection(UnixSocketFile)
-	if err != nil {
-		t.Fatal("Unable to connect to the VRS")
+	fakeTable := &testutils.FakeTable{}
+
+	vrsConnection := VRSConnection{
+		controllerTable: fakeTable,
 	}
 
-	state, err = vrsConnection.GetControllerState()
-	if err != nil {
-		t.Fatalf("error getting controller state")
+	vec := []controllerTableTestVec{
+		{func(ovs *libovsdb.OvsdbClient, readRowArgs ovsdb.ReadRowArgs) ([]map[string]interface{}, error) {
+			m := make([]map[string]interface{}, 1)
+			return m, nil
+		}, ControllerConnected, nil},
+		{func(ovs *libovsdb.OvsdbClient, readRowArgs ovsdb.ReadRowArgs) ([]map[string]interface{}, error) {
+			m := make([]map[string]interface{}, 0)
+			return m, nil
+		}, ControllerDisconnected, nil},
+		{func(ovs *libovsdb.OvsdbClient, readRowArgs ovsdb.ReadRowArgs) ([]map[string]interface{}, error) {
+			return nil, fmt.Errorf("some random error")
+		}, ControllerStateUnknown, fmt.Errorf("some random error")},
 	}
 
-	if state != ControllerConnected {
-		t.Fatalf("controller state is not connected")
+	for _, tt := range vec {
+		fakeTable.ReadRowsFunc = tt.readRows
+		state, err := vrsConnection.GetControllerState()
+		if tt.out != state {
+			t.Fatalf("controller state %v did not match expected %v", state, tt.out)
+		}
+		if err != nil && tt.err != nil && !strings.Contains(err.Error(), tt.err.Error()) {
+			t.Fatalf("errors did not match: expected %v found %v", err.Error(), tt.err.Error())
+		}
+		if tt.err != nil && err == nil {
+			t.Fatalf("expected non nil error %v but found", tt.err)
+		}
+		if tt.err == nil && err != nil {
+			t.Fatalf("expected nil error but found %v", err)
+		}
+
 	}
 }

--- a/api/Controller_test.go
+++ b/api/Controller_test.go
@@ -1,0 +1,23 @@
+package api
+
+import "testing"
+
+func TestGetControllerState(t *testing.T) {
+	var err error
+	var state ControllerState
+	var vrsConnection VRSConnection
+
+	vrsConnection, err = NewUnixSocketConnection(UnixSocketFile)
+	if err != nil {
+		t.Fatal("Unable to connect to the VRS")
+	}
+
+	state, err = vrsConnection.GetControllerState()
+	if err != nil {
+		t.Fatalf("error getting controller state")
+	}
+
+	if state != ControllerConnected {
+		t.Fatalf("controller state is not connected")
+	}
+}

--- a/api/VRSConnection.go
+++ b/api/VRSConnection.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+
 	"github.com/nuagenetworks/libvrsdk/ovsdb"
 	"github.com/socketplane/libovsdb"
 )
@@ -23,6 +24,7 @@ type VRSConnection struct {
 	ovsdbClient         *libovsdb.OvsdbClient
 	vmTable             ovsdb.NuageTable
 	portTable           ovsdb.NuageTable
+	controllerTable     ovsdb.NuageTable
 	updatesChan         chan *libovsdb.TableUpdates
 	pncTable            portNameChannelMap
 	pnpTable            portNamePortInfoMap
@@ -63,6 +65,7 @@ func NewUnixSocketConnection(socketfile string) (VRSConnection, error) {
 
 	vrsConnection.vmTable.TableName = ovsdb.NuageVMTable
 	vrsConnection.portTable.TableName = ovsdb.NuagePortTable
+	vrsConnection.controllerTable.TableName = ovsdb.ControllerTable
 	vrsConnection.pncTable = make(portNameChannelMap)
 	vrsConnection.pnpTable = make(portNamePortInfoMap)
 	vrsConnection.registrationChannel = make(chan *Registration)

--- a/api/VRSConnection.go
+++ b/api/VRSConnection.go
@@ -22,9 +22,9 @@ type Registration struct {
 // VRSConnection represent the OVSDB connection to the VRS
 type VRSConnection struct {
 	ovsdbClient         *libovsdb.OvsdbClient
-	vmTable             ovsdb.NuageTable
-	portTable           ovsdb.NuageTable
-	controllerTable     ovsdb.NuageTable
+	vmTable             ovsdb.NuageTableOps
+	portTable           ovsdb.NuageTableOps
+	controllerTable     ovsdb.NuageTableOps
 	updatesChan         chan *libovsdb.TableUpdates
 	pncTable            portNameChannelMap
 	pnpTable            portNamePortInfoMap
@@ -63,9 +63,9 @@ func NewUnixSocketConnection(socketfile string) (VRSConnection, error) {
 		return vrsConnection, err
 	}
 
-	vrsConnection.vmTable.TableName = ovsdb.NuageVMTable
-	vrsConnection.portTable.TableName = ovsdb.NuagePortTable
-	vrsConnection.controllerTable.TableName = ovsdb.ControllerTable
+	vrsConnection.vmTable = &ovsdb.NuageTable{TableName: ovsdb.NuageVMTable}
+	vrsConnection.portTable = &ovsdb.NuageTable{TableName: ovsdb.NuagePortTable}
+	vrsConnection.controllerTable = &ovsdb.NuageTable{TableName: ovsdb.ControllerTable}
 	vrsConnection.pncTable = make(portNameChannelMap)
 	vrsConnection.pnpTable = make(portNamePortInfoMap)
 	vrsConnection.registrationChannel = make(chan *Registration)

--- a/api/port/State.go
+++ b/api/port/State.go
@@ -7,9 +7,12 @@ type StateKey string
 
 // Keys to query the state of the port
 const (
-	StateKeyIPAddress  StateKey = ovsdb.NuagePortTableColumnIPAddress
-	StateKeySubnetMask StateKey = ovsdb.NuagePortTableColumnSubnetMask
-	StateKeyGateway    StateKey = ovsdb.NuagePortTableColumnGateway
-	StateKeyVrfID      StateKey = ovsdb.NuagePortTableColumnVRFId
-	StateKeyEvpnID     StateKey = ovsdb.NuagePortTableColumnEVPNID
+	StateKeyIPAddress    StateKey = ovsdb.NuagePortTableColumnIPAddress
+	StateKeySubnetMask   StateKey = ovsdb.NuagePortTableColumnSubnetMask
+	StateKeyGateway      StateKey = ovsdb.NuagePortTableColumnGateway
+	StateKeyVrfID        StateKey = ovsdb.NuagePortTableColumnVRFId
+	StateKeyEvpnID       StateKey = ovsdb.NuagePortTableColumnEVPNID
+	StateKeyNuageDomain  StateKey = ovsdb.NuagePortTableColumnNuageDomain
+	StateKeyNuageZone    StateKey = ovsdb.NuagePortTableColumnNuageZone
+	StateKeyNuageNetwork StateKey = ovsdb.NuagePortTableColumnNuageNetwork
 )

--- a/ovsdb/ControllerTableRow.go
+++ b/ovsdb/ControllerTableRow.go
@@ -1,0 +1,26 @@
+package ovsdb
+
+const (
+	//ControllerTable is the table name
+	ControllerTable = "Controller"
+	//ControllerTableColumnRole column role in controller table
+	ControllerTableColumnRole = "role"
+)
+
+//ControllerTableRow represents a row in Controller Table
+type ControllerTableRow struct {
+	Role string
+}
+
+//Equals checks for equality of two rows in Controller Table
+func (row *ControllerTableRow) Equals(otherRow interface{}) bool {
+	controllerTableRow, ok := otherRow.(ControllerTableRow)
+	if !ok {
+		return false
+	}
+
+	if row.Role != controllerTableRow.Role {
+		return false
+	}
+	return true
+}

--- a/ovsdb/NuagePortTable_test.go
+++ b/ovsdb/NuagePortTable_test.go
@@ -2,12 +2,13 @@ package ovsdb
 
 import (
 	"fmt"
-	"github.com/nuagenetworks/libvrsdk/api/entity"
-	"github.com/socketplane/libovsdb"
 	"math/rand"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nuagenetworks/libvrsdk/api/entity"
+	"github.com/socketplane/libovsdb"
 )
 
 const mac1 = "76:22:F6:70:4E:47"

--- a/ovsdb/NuageTable.go
+++ b/ovsdb/NuageTable.go
@@ -2,12 +2,21 @@ package ovsdb
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/socketplane/libovsdb"
 )
 
 // OvsDBName is the OVS database name
 const OvsDBName = "Open_vSwitch"
+
+type NuageTableOps interface {
+	InsertRow(ovs *libovsdb.OvsdbClient, row NuageTableRow) error
+	DeleteRow(ovs *libovsdb.OvsdbClient, condition []string) error
+	ReadRow(ovs *libovsdb.OvsdbClient, readRowArgs ReadRowArgs) (map[string]interface{}, error)
+	ReadRows(ovs *libovsdb.OvsdbClient, readRowArgs ReadRowArgs) ([]map[string]interface{}, error)
+	UpdateRow(ovs *libovsdb.OvsdbClient, ovsdbRow map[string]interface{}, condition []string) error
+}
 
 // NuageTable represent a Nuage OVSDB table
 type NuageTable struct {
@@ -45,7 +54,7 @@ func (nuageTable *NuageTable) InsertRow(ovs *libovsdb.OvsdbClient, row NuageTabl
 		return (errStr)
 	}
 
-	glog.V(2).Info("Insertion into Nuage VM Table succeeded with UUID %s", reply[0].UUID)
+	glog.V(2).Infof("Insertion into Nuage VM Table succeeded with UUID %s", reply[0].UUID)
 
 	return nil
 }

--- a/ovsdb/NuageVMTableRow.go
+++ b/ovsdb/NuageVMTableRow.go
@@ -1,15 +1,17 @@
 package ovsdb
 
 import (
-	"github.com/nuagenetworks/libvrsdk/api/entity"
-	"github.com/socketplane/libovsdb"
 	"reflect"
 	"strings"
+
+	"github.com/nuagenetworks/libvrsdk/api/entity"
+	"github.com/socketplane/libovsdb"
 )
 
 // These constants describe the Nuage_VM_Table
 const (
 	NuageVMTable                    = "Nuage_VM_Table"
+	NuageVMTableColumnVMName        = "vm_name"
 	NuageVMTableColumnVMUUID        = "vm_uuid"
 	NuageVMTableColumnPorts         = "ports"
 	NuageVMTableColumnState         = "state"

--- a/test/util/table/fake_controller_table.go
+++ b/test/util/table/fake_controller_table.go
@@ -1,0 +1,41 @@
+package table
+
+import (
+	"github.com/nuagenetworks/libvrsdk/ovsdb"
+	"github.com/socketplane/libovsdb"
+)
+
+//FakeTable is a fake table that can be used for testing
+type FakeTable struct {
+	ReadRowsFunc func(ovs *libovsdb.OvsdbClient, readRowArgs ovsdb.ReadRowArgs) ([]map[string]interface{}, error)
+}
+
+//InsertRow inserts a row into table
+func (f *FakeTable) InsertRow(ovs *libovsdb.OvsdbClient, row ovsdb.NuageTableRow) error {
+	return nil
+}
+
+//DeleteRow deletes a row from table
+func (f *FakeTable) DeleteRow(ovs *libovsdb.OvsdbClient, condition []string) error {
+	return nil
+}
+
+//ReadRow read one row matching readRowArgs
+func (f *FakeTable) ReadRow(ovs *libovsdb.OvsdbClient, readRowArgs ovsdb.ReadRowArgs) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+	return m, nil
+}
+
+//ReadRows returns all the rows matching readRowArgs
+func (f *FakeTable) ReadRows(ovs *libovsdb.OvsdbClient, readRowArgs ovsdb.ReadRowArgs) ([]map[string]interface{}, error) {
+	if f.ReadRowsFunc != nil {
+		return f.ReadRowsFunc(ovs, readRowArgs)
+	}
+	m := make([]map[string]interface{}, 10)
+	return m, nil
+}
+
+//UpdateRow updates the row in the table
+func (f *FakeTable) UpdateRow(ovs *libovsdb.OvsdbClient, ovsdbRow map[string]interface{}, condition []string) error {
+	return nil
+}


### PR DESCRIPTION
This api can be used to determine the state of the controller. It relies on Open_vSwitch `Controller` table  `role` column.